### PR TITLE
文字化け防止のためcharsetを指定

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -81,6 +81,7 @@ const indexPage: string =
 `<html>
 <head>
   <title>Piping</title>
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     h3 {


### PR DESCRIPTION
文字化け防止のためcharsetを指定しました。

僕の環境だと文字化けしました。
<img width="678" alt="Screen Shot 2019-09-19 at 19 37 20" src="https://user-images.githubusercontent.com/10933561/65237528-c6f12780-db15-11e9-9917-4a84895346be.png">

このプルリクエストをマージすると以下のように僕の環境でも文字化けしなくなりました。
![image](https://user-images.githubusercontent.com/10933561/65237539-cb1d4500-db15-11e9-851d-d8848d9e38e9.png)
